### PR TITLE
Set proper keyword name

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
         {
             "id": "kw",
             "type": "keyword",
-            "name": "Keyword",
+            "name": "Lorem Ipsum",
             "default_value": "lipsum"
         }
     ]


### PR DESCRIPTION
Set keyword name to "Lorem Ipsum" so you can type either "Lorem" or "Ipsum" in addition to just "lipsum" (like https://github.com/brpaz/ulauncher-hash/pull/2).

In addition to this, the preferences will show "Lorem Ipsum Keyword", not "Keyword Keyword".

### Before

![screenshot from 2018-09-12 18-36-40](https://user-images.githubusercontent.com/515120/45439712-da73e200-b6ba-11e8-9294-cb46ad3808c6.png)

![screenshot from 2018-09-12 18-31-58](https://user-images.githubusercontent.com/515120/45439753-f1b2cf80-b6ba-11e8-9afb-fb42a24256ba.png)

### After

![screenshot from 2018-09-12 18-38-22](https://user-images.githubusercontent.com/515120/45439818-1313bb80-b6bb-11e8-95bf-224b383a0bac.png)

![screenshot from 2018-09-12 18-30-23](https://user-images.githubusercontent.com/515120/45439823-18710600-b6bb-11e8-98df-e25bd76ac81b.png)
